### PR TITLE
[outline-writer] Allow background color for outline items.

### DIFF
--- a/outline-writer/README.md
+++ b/outline-writer/README.md
@@ -47,6 +47,7 @@ Display text outline, gathered from files with synopsis in YAML front matter.
 This extension supports the following fields in YAML front matter:
 * `title`: May be empty, defaults to the filename.
 * `synopsis`: May be empty, defaults to empty string.
+* `color`: Background color (only applies to HTML format) in CSS hex color format. May be empty, defaults to transparent.
 
 The generated outline is accessible either via the Activity Bar, or via the context menu when right-clicking a `.outline` file in the File Explorer.
 
@@ -56,6 +57,8 @@ The generated outline is accessible either via the Activity Bar, or via the cont
 This extension contributes the following settings:
 
 * `outline-writer.outlineFormat`: which format the outline should be rendered as.
+* `outline-writer.defaultColor`: default color for items in the outline (only applies to HTML format)
+* `outline-writer.noteColor`: color for notes in the outline (only applies to HTML format)
 
 
 #### Icon

--- a/outline-writer/package.json
+++ b/outline-writer/package.json
@@ -43,6 +43,18 @@
                         "Format the outline as plain text.",
                         "Format the outline as Markdown."
                     ]
+                },
+                "outline-writer.defaultColor": {
+                    "type": ["string", "null"],
+                    "format": "color-hex",
+                    "default": null,
+                    "description": "Default background color of items."
+                },
+                "outline-writer.noteColor": {
+                    "type": ["string", "null"],
+                    "format": "color-hex",
+                    "default": null,
+                    "description": "Background color of notes."
                 }
             }
         },

--- a/outline-writer/src/Color.ts
+++ b/outline-writer/src/Color.ts
@@ -1,0 +1,113 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License.
+ *--------------------------------------------------------------------------------------------*/
+
+export interface RGBA {
+    /**
+     * Red: integer in [0-255]
+     */
+    readonly r: number;
+
+    /**
+     * Green: integer in [0-255]
+     */
+    readonly g: number;
+
+    /**
+     * Blue: integer in [0-255]
+     */
+    readonly b: number;
+
+    /**
+     * Alpha: float in [0-1]
+     */
+    readonly a: number;
+}
+
+export function parseHex(hex?: string): RGBA | null {
+    if (!hex) {
+        return null;
+    }
+
+    const length = hex.length;
+
+    if (length === 0) {
+        // Invalid color
+        return null;
+    }
+
+    if (hex.charAt(0) !== '#') {
+        // Does not begin with a #
+        return null;
+    }
+
+    if (length === 7) {
+        // #RRGGBB format
+        const r = 16 * _parseHexDigit(hex.charAt(1)) + _parseHexDigit(hex.charAt(2));
+        const g = 16 * _parseHexDigit(hex.charAt(3)) + _parseHexDigit(hex.charAt(4));
+        const b = 16 * _parseHexDigit(hex.charAt(5)) + _parseHexDigit(hex.charAt(6));
+        return { r, g, b, a: 1 };
+    }
+
+    if (length === 9) {
+        // #RRGGBBAA format
+        const r = 16 * _parseHexDigit(hex.charAt(1)) + _parseHexDigit(hex.charAt(2));
+        const g = 16 * _parseHexDigit(hex.charAt(3)) + _parseHexDigit(hex.charAt(4));
+        const b = 16 * _parseHexDigit(hex.charAt(5)) + _parseHexDigit(hex.charAt(6));
+        const a = 16 * _parseHexDigit(hex.charAt(7)) + _parseHexDigit(hex.charAt(8));
+        return { r, g, b, a: a / 255 };
+    }
+
+    if (length === 4) {
+        // #RGB format
+        const r = _parseHexDigit(hex.charAt(1));
+        const g = _parseHexDigit(hex.charAt(2));
+        const b = _parseHexDigit(hex.charAt(3));
+        return {
+            r: 16 * r + r,
+            g: 16 * g + g,
+            b: 16 * b + b,
+            a: 1
+        };
+    }
+
+    if (length === 5) {
+        // #RGBA format
+        const r = _parseHexDigit(hex.charAt(1));
+        const g = _parseHexDigit(hex.charAt(2));
+        const b = _parseHexDigit(hex.charAt(3));
+        const a = _parseHexDigit(hex.charAt(4));
+        return {
+            r: 16 * r + r,
+            g: 16 * g + g,
+            b: 16 * b + b,
+            a: (16 * a + a) / 255
+        };
+    }
+
+    // Invalid color
+    return null;
+}
+
+function _parseHexDigit(char: string): number {
+    switch (char.toLowerCase()) {
+        case '0': return 0;
+        case '1': return 1;
+        case '2': return 2;
+        case '3': return 3;
+        case '4': return 4;
+        case '5': return 5;
+        case '6': return 6;
+        case '7': return 7;
+        case '8': return 8;
+        case '9': return 9;
+        case 'a': return 10;
+        case 'b': return 11;
+        case 'c': return 12;
+        case 'd': return 13;
+        case 'e': return 14;
+        case 'f': return 15;
+    }
+    return 0;
+}

--- a/outline-writer/src/HtmlRenderer.ts
+++ b/outline-writer/src/HtmlRenderer.ts
@@ -1,5 +1,6 @@
 import path from 'path';
 import * as vscode from 'vscode';
+import { RGBA } from './Color';
 import Outline, { OutlineItem } from './Outline';
 
 export default class HtmlRenderer implements vscode.Disposable {
@@ -44,7 +45,7 @@ export default class HtmlRenderer implements vscode.Disposable {
                 <meta charset="UTF-8">
                 <meta http-equiv="Content-Security-Policy" content="
                     default-src 'none';
-                    style-src ${webview.cspSource};
+                    style-src ${webview.cspSource} 'unsafe-inline';
                     ">
                 <meta name="viewport" content="width=device-width, initial-scale=1.0">
                 <link href="${styleUri}" rel="stylesheet">
@@ -81,8 +82,9 @@ export default class HtmlRenderer implements vscode.Disposable {
             renderedText = await vscode.commands.executeCommand('markdown.api.render', item.text);
         }
 
+        const customStyle = item.color ? `style="background-color: ${this.formatColorString(item.color)};"` : '';
         const itemHtml = `
-        <div class="outline-item">
+        <div class="outline-item" ${customStyle}>
             <div class="outline-title">${item.title}</div>
             <div class="outline-text">${renderedText}</div>
         </div>
@@ -93,5 +95,9 @@ export default class HtmlRenderer implements vscode.Disposable {
 
     dispose() {
         this.panel?.dispose();
+    }
+
+    private formatColorString(color: RGBA): string {
+        return `rgba(${color.r}, ${color.g}, ${color.b}, ${color.a.toFixed(2)})`;
     }
 }

--- a/outline-writer/src/OutlineConfig.ts
+++ b/outline-writer/src/OutlineConfig.ts
@@ -1,0 +1,6 @@
+import { RGBA } from './Color';
+
+export default interface OutlineConfig {
+    defaultColor?: RGBA,
+    noteColor?: RGBA
+}

--- a/outline-writer/src/OutlineParser.ts
+++ b/outline-writer/src/OutlineParser.ts
@@ -1,23 +1,32 @@
 import { promises as fs } from 'fs';
 import Outline from './Outline';
+import OutlineConfig from './OutlineConfig';
 
-function filterEmptyLines(files: string): string[] {
-    if (!files) {
-        return [];
+export default class OutlineParser {
+    private config: OutlineConfig = {}
+
+    setConfig(config: OutlineConfig) {
+        this.config = config;
     }
 
-    // filter out empty lines
-    return files.split('\n').filter((f) => f.trim().length > 0);
-}
+    async getOutline(outlineFilename: string): Promise<Outline | null> {
+        let outlineList = null;
+        try {
+            outlineList = await fs.readFile(outlineFilename, { encoding: 'utf-8' });
+        } catch (err: any) {
+            console.error(`Could not load outline: ${err}`);
+            return null;
+        }
 
-export default async function getOutline(outlineFilename: string): Promise<Outline | null> {
-    let outlineList = null;
-    try {
-        outlineList = await fs.readFile(outlineFilename, { encoding: 'utf-8' });
-    } catch (err: any) {
-        console.error(`Could not load outline: ${err}`);
-        return null;
+        return await Outline.fromList(outlineFilename, this.filterEmptyLines(outlineList), this.config);
     }
 
-    return await Outline.fromList(outlineFilename, filterEmptyLines(outlineList));
+    private filterEmptyLines(files: string): string[] {
+        if (!files) {
+            return [];
+        }
+
+        // filter out empty lines
+        return files.split('\n').filter((f) => f.trim().length > 0);
+    }
 }


### PR DESCRIPTION
Globally configurable via 'outline-writer.{defaultColor,noteColor}'
or per file via 'color' in YAML front matter.