### PR TITLE
[outline-writer] Persist scroll position of rendered HTML outline.

### DIFF
--- a/outline-writer/media/main.js
+++ b/outline-writer/media/main.js
@@ -1,0 +1,9 @@
+const vscode = acquireVsCodeApi();
+
+const previousState = vscode.getState();
+let scrollY = previousState ? previousState.scrollY : 0;
+window.scroll({ top: scrollY });
+
+document.addEventListener('scroll', () => {
+    vscode.setState({ scrollY: window.scrollY });
+});

--- a/outline-writer/src/HtmlRenderer.ts
+++ b/outline-writer/src/HtmlRenderer.ts
@@ -22,6 +22,7 @@ export default class HtmlRenderer implements vscode.Disposable {
                 vscode.ViewColumn.One,
                 {
                     enableFindWidget: true,
+                    enableScripts: true,
                     localResourceRoots: [vscode.Uri.joinPath(this.extensionUri, 'media')],
                 }
             );
@@ -36,6 +37,7 @@ export default class HtmlRenderer implements vscode.Disposable {
 
     private async getHtmlForWebview(outline: Outline, webview: vscode.Webview): Promise<string> {
         const styleUri = webview.asWebviewUri(vscode.Uri.joinPath(this.extensionUri, 'media', 'main.css'));
+        const jsUri = webview.asWebviewUri(vscode.Uri.joinPath(this.extensionUri, 'media', 'main.js'));
 
         const outlineContent = await this.outlineHtml(outline);
         const html = `
@@ -46,9 +48,11 @@ export default class HtmlRenderer implements vscode.Disposable {
                 <meta http-equiv="Content-Security-Policy" content="
                     default-src 'none';
                     style-src ${webview.cspSource} 'unsafe-inline';
+                    script-src ${webview.cspSource};
                     ">
                 <meta name="viewport" content="width=device-width, initial-scale=1.0">
                 <link href="${styleUri}" rel="stylesheet">
+                <script defer src="${jsUri}"></script>
 
                 <title>Outline View</title>
             </head>


### PR DESCRIPTION
Avoids jumping back to the top of the outline every time the web view
is destroyed when it is hidden.