### PR TITLE
[outline-writer] Properly center title in HTML outline.

### DIFF
--- a/outline-writer/media/main.css
+++ b/outline-writer/media/main.css
@@ -12,11 +12,16 @@
 }
 
 .outline-title-row {
-    display: flex;
+    display: grid;
+    grid-template-columns: 1fr auto 1fr;
+}
+
+.outline-title-row :nth-child(2) {
+    justify-self: end;
 }
 
 .outline-title {
-    flex-grow: 1;
+    grid-column-start: 2;
     text-align: center;
     font-weight: bold;
     font-size: medium;


### PR DESCRIPTION
Previously the title was only centered within the remaining space next
to the index text.